### PR TITLE
Map proxy url prefix based on request uri

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,10 @@
 # rawgit
 
+map $request_uri $detect_proxy_url_prefix {
+    ~*^/images/galleries  https://media.githubusercontent.com/media/ElixirRuhr/elixir.ruhr;
+    default               https://raw.githubusercontent.com/ElixirRuhr/elixir.ruhr;
+}
+
 # file extension to mime-type mapping
 # kind of workaround because nginx can detect mime-type only for local file
 map $extension $detect_content_type {

--- a/proxy.conf
+++ b/proxy.conf
@@ -17,7 +17,7 @@ location ~* ^.+\.(?<extension>[a-zA-Z0-9]+)$ {
     # to be able to resolve remote server name from a variable
     resolver 8.8.8.8;
 
-    set $gh_url https://raw.githubusercontent.com/ElixirRuhr/elixir.ruhr/$git_sha$uri;
+    set $gh_url $detect_proxy_url_prefix/$git_sha$uri;
 
     # if we do not know this extension, let's redirect
     if ($detect_content_type = '') {


### PR DESCRIPTION
All images in `/images/galleries` are stored via Git LFS so have to
fetch them directly from `media.githubusercontent.com`

Depends on #1 